### PR TITLE
Fix format dfh

### DIFF
--- a/vue-luxon.js
+++ b/vue-luxon.js
@@ -122,9 +122,8 @@ module.exports = {
           options.diffForHumans ? options.diffForHumans.durations : undefined
         )
         .toObject();
-      const objProperties = Object.getOwnPropertyNames(obj)
-      let closestName = objProperties[objProperties.length - 1];
-      let isNow = obj[closestName] < 1;
+      const closestName = Object.getOwnPropertyNames(obj).find(key => obj[key] > 0);
+      const isNow = !closestName;
       return trans(
         closestName,
         obj[closestName],


### PR DESCRIPTION
Currently the format_dfh would return 'just now' as it would only check for the first item in the duration array (this defaults to year). If the time ago was less than 1 year it would show just now instead.